### PR TITLE
Fix: use a later initHook for parsing links (fixes #1)

### DIFF
--- a/src/main/epics/irio-epicsApp/src/irioAsyn.c
+++ b/src/main/epics/irio-epicsApp/src/irioAsyn.c
@@ -30,7 +30,7 @@ static void gettingDBInfo(initHookState state)
 	int i=0,j=0;
 
 	switch (state){
-	case initHookAtBeginning:
+    case initHookAfterInitDatabase:
 		if (call_gettingDBInfo==0){
 			for(j=0;j<MAX_NUMBER_OF_CARDS;j++){
 				if(globalData[j].init_success==1){


### PR DESCRIPTION
In Base 3.16 the link parsing has been changed and partially moved to a later step in iocInit().
This fix moves the link parsing that IRIO EPICS does to happen after Base has completely done its own parsing.